### PR TITLE
Sets up basic event framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/*
 *.iws
 *.iml
 *.ipr

--- a/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
+++ b/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
@@ -1,0 +1,19 @@
+package io.github.ryanlaverick;
+
+import io.github.ryanlaverick.listener.CustomToolUsedListener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class AlchemicalTools extends JavaPlugin {
+
+    @Override
+    public void onEnable() {
+        this.getLogger().info("Plugin Enabled");
+
+        this.getServer().getPluginManager().registerEvents(new CustomToolUsedListener(), this);
+    }
+
+    @Override
+    public void onDisable() {
+        this.getLogger().info("Plugin Disabled");
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
+++ b/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
@@ -1,6 +1,7 @@
 package io.github.ryanlaverick;
 
 import io.github.ryanlaverick.listener.CustomToolUsedListener;
+import io.github.ryanlaverick.listener.TriggerCustomToolUsedListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class AlchemicalTools extends JavaPlugin {
@@ -9,6 +10,7 @@ public class AlchemicalTools extends JavaPlugin {
     public void onEnable() {
         this.getLogger().info("Plugin Enabled");
 
+        this.getServer().getPluginManager().registerEvents(new TriggerCustomToolUsedListener(), this);
         this.getServer().getPluginManager().registerEvents(new CustomToolUsedListener(), this);
     }
 

--- a/src/main/java/io/github/ryanlaverick/event/CustomToolUsedEvent.java
+++ b/src/main/java/io/github/ryanlaverick/event/CustomToolUsedEvent.java
@@ -1,0 +1,48 @@
+package io.github.ryanlaverick.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+public final class CustomToolUsedEvent extends Event implements Cancellable {
+    private final Player player;
+    private final ItemStack triggeringItem;
+
+    private boolean isCancelled;
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    public CustomToolUsedEvent(Player player, ItemStack triggeringItem) {
+        this.player = player;
+        this.triggeringItem = triggeringItem;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        isCancelled = cancelled;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public ItemStack getTriggeringItem() {
+        return triggeringItem;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/listener/CustomToolUsedListener.java
+++ b/src/main/java/io/github/ryanlaverick/listener/CustomToolUsedListener.java
@@ -1,0 +1,24 @@
+package io.github.ryanlaverick.listener;
+
+import io.github.ryanlaverick.event.CustomToolUsedEvent;
+import io.github.ryanlaverick.item.NBTUtility;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+public final class CustomToolUsedListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBreak(BlockBreakEvent event) {
+        if (event.isCancelled()) return;
+
+        ItemStack itemInHand = event.getPlayer().getInventory().getItemInMainHand();
+
+        if (itemInHand.getType().isAir()) return;
+
+        Bukkit.getServer().getPluginManager().callEvent(new CustomToolUsedEvent(event.getPlayer(), itemInHand));
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/listener/CustomToolUsedListener.java
+++ b/src/main/java/io/github/ryanlaverick/listener/CustomToolUsedListener.java
@@ -1,24 +1,18 @@
 package io.github.ryanlaverick.listener;
 
 import io.github.ryanlaverick.event.CustomToolUsedEvent;
-import io.github.ryanlaverick.item.NBTUtility;
-import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.inventory.ItemStack;
 
 public final class CustomToolUsedListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
-    public void onBreak(BlockBreakEvent event) {
+    public void onUse(CustomToolUsedEvent event) {
         if (event.isCancelled()) return;
 
-        ItemStack itemInHand = event.getPlayer().getInventory().getItemInMainHand();
-
-        if (itemInHand.getType().isAir()) return;
-
-        Bukkit.getServer().getPluginManager().callEvent(new CustomToolUsedEvent(event.getPlayer(), itemInHand));
+        Player player = event.getPlayer();
+        player.sendMessage("Used Tool!");
     }
 }

--- a/src/main/java/io/github/ryanlaverick/listener/TriggerCustomToolUsedListener.java
+++ b/src/main/java/io/github/ryanlaverick/listener/TriggerCustomToolUsedListener.java
@@ -1,0 +1,23 @@
+package io.github.ryanlaverick.listener;
+
+import io.github.ryanlaverick.event.CustomToolUsedEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+public final class TriggerCustomToolUsedListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBreak(BlockBreakEvent event) {
+        if (event.isCancelled()) return;
+
+        ItemStack itemInHand = event.getPlayer().getInventory().getItemInMainHand();
+
+        if (itemInHand.getType().isAir()) return;
+
+        Bukkit.getServer().getPluginManager().callEvent(new CustomToolUsedEvent(event.getPlayer(), itemInHand));
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,5 @@
+name: AlchemicalTools
+version: 0.0.1-SNAPSHOT
+main: io.github.ryanlaverick.AlchemicalTools
+api-version: 1.19
+author: Ryan Laverick (Novur)


### PR DESCRIPTION
Includes initial custom event for detecting if/when an Alchemical Tool is used. Currently does not do any validation on _what_ is classified as an AT -- this will be re-worked once the item framework is set up.

Previously we just listened to `BlockBreakEvent`, which makes it trickier for third party plugins to hook into AT as there is no common way of identifying when a tool is used versus a regular Minecraft item.