### PR TITLE
Setup basic command framework

### DIFF
--- a/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
+++ b/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
@@ -1,5 +1,6 @@
 package io.github.ryanlaverick;
 
+import io.github.ryanlaverick.command.AlchemicalToolsCommand;
 import io.github.ryanlaverick.listener.CustomToolUsedListener;
 import io.github.ryanlaverick.listener.TriggerCustomToolUsedListener;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -12,6 +13,8 @@ public class AlchemicalTools extends JavaPlugin {
 
         this.getServer().getPluginManager().registerEvents(new TriggerCustomToolUsedListener(), this);
         this.getServer().getPluginManager().registerEvents(new CustomToolUsedListener(), this);
+
+        this.getCommand("alchemicaltools").setExecutor(new AlchemicalToolsCommand());
     }
 
     @Override

--- a/src/main/java/io/github/ryanlaverick/command/AlchemicalToolsCommand.java
+++ b/src/main/java/io/github/ryanlaverick/command/AlchemicalToolsCommand.java
@@ -1,0 +1,41 @@
+package io.github.ryanlaverick.command;
+
+import io.github.ryanlaverick.framework.command.AggregateCommand;
+import io.github.ryanlaverick.command.subcommands.GiveToolSubCommand;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public final class AlchemicalToolsCommand extends AggregateCommand {
+    public AlchemicalToolsCommand() {
+        this.registerSubCommand("give", new GiveToolSubCommand());
+    }
+
+    @Override
+    public String getName() {
+        return "alchemicaltools";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Root command for AlchemicalTools.";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "/alchemicaltools";
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (sender instanceof Player) {
+            if (! sender.hasPermission("alchemicaltools.commands.help")) {
+                sender.sendMessage("No permission");
+
+                return true;
+            }
+        }
+
+        return super.onCommand(sender, command, label, args);
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/command/subcommands/GiveToolSubCommand.java
+++ b/src/main/java/io/github/ryanlaverick/command/subcommands/GiveToolSubCommand.java
@@ -1,0 +1,61 @@
+package io.github.ryanlaverick.command.subcommands;
+
+import io.github.ryanlaverick.framework.command.SubCommand;
+import io.github.ryanlaverick.item.Tool;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public final class GiveToolSubCommand extends SubCommand {
+    @Override
+    public String getName() {
+        return "alchemicaltools_give";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Grants a given Player the power of an AlchemicalTool.";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "/alchemicaltools give <player> <tool>";
+    }
+
+    @Override
+    public boolean execute(CommandSender commandSender, String[] args) {
+        if (commandSender instanceof Player) {
+            if (! commandSender.hasPermission("alchemicaltools.commands.give")) {
+                commandSender.sendMessage("Missing permission for give command");
+
+                return true;
+            }
+
+            if (args.length != 3) {
+                this.sendCommandHelp(commandSender);
+
+                return true;
+            }
+
+            Player targetPlayer = Bukkit.getPlayer(args[1]);
+
+            if (targetPlayer == null) {
+                commandSender.sendMessage("Player not found");
+
+                return true;
+            }
+
+            Tool tool = Tool.tryFrom(args[2]);
+
+            if (tool == null) {
+                commandSender.sendMessage("Tool not found");
+
+                return true;
+            }
+
+            commandSender.sendMessage("Giving player " + targetPlayer.getName() + " tool " + tool.getName());
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/framework/command/AggregateCommand.java
+++ b/src/main/java/io/github/ryanlaverick/framework/command/AggregateCommand.java
@@ -1,0 +1,74 @@
+package io.github.ryanlaverick.framework.command;
+
+import io.github.ryanlaverick.framework.command.exception.SubCommandAlreadyMappedException;
+import io.github.ryanlaverick.framework.utility.StringFormatter;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class AggregateCommand implements ICommand, CommandExecutor {
+    protected final Map<String, SubCommand> subCommands;
+
+    protected AggregateCommand() {
+        this.subCommands = new HashMap<>();
+    }
+
+    public boolean isMapped(String prefix) {
+        return this.subCommands.containsKey(prefix);
+    }
+
+    public void registerSubCommand(String prefix, SubCommand subCommand) {
+        if (this.isMapped(prefix)) {
+            throw new SubCommandAlreadyMappedException(this.getName(), subCommand.getName());
+        }
+
+        this.subCommands.put(prefix, subCommand);
+    }
+
+    public SubCommand getSubCommand(String prefix) {
+        return this.getSubCommands().get(prefix);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            this.sendCommandList(sender);
+            return true;
+        }
+
+        String prefix = args[0];
+
+        if (! this.isMapped(prefix)) {
+            this.sendCommandList(sender);
+            return true;
+        }
+
+        return this.getSubCommand(prefix).execute(sender, args);
+    }
+
+    protected void sendCommandList(CommandSender commandSender) {
+        commandSender.sendMessage(StringFormatter.translateColorCodes(
+                "&8&m         &2( &2&lAlchemicalTools &2) &8&m        "
+        ));
+
+        for (Map.Entry<String, SubCommand> subCommandEntry : this.getSubCommands().entrySet()) {
+            String syntax = subCommandEntry.getValue().getSyntax();
+            String description = subCommandEntry.getValue().getDescription();
+
+            commandSender.sendMessage(StringFormatter.translateColorCodes(
+                    "&2{syntax} &8- {description}".replace("{syntax}", syntax).replace("{description}", description)
+            ));
+        }
+
+        commandSender.sendMessage(StringFormatter.translateColorCodes(
+                "&8&m                                                 "
+        ));
+    }
+
+    public Map<String, SubCommand> getSubCommands() {
+        return subCommands;
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/framework/command/ICommand.java
+++ b/src/main/java/io/github/ryanlaverick/framework/command/ICommand.java
@@ -1,0 +1,9 @@
+package io.github.ryanlaverick.framework.command;
+
+public interface ICommand {
+    String getName();
+
+    String getDescription();
+
+    String getSyntax();
+}

--- a/src/main/java/io/github/ryanlaverick/framework/command/SubCommand.java
+++ b/src/main/java/io/github/ryanlaverick/framework/command/SubCommand.java
@@ -1,0 +1,22 @@
+package io.github.ryanlaverick.framework.command;
+
+import io.github.ryanlaverick.framework.utility.StringFormatter;
+import org.bukkit.command.CommandSender;
+
+public abstract class SubCommand implements ICommand {
+    public abstract boolean execute(CommandSender commandSender, String[] args);
+
+    protected void sendCommandHelp(CommandSender commandSender) {
+        commandSender.sendMessage(StringFormatter.translateColorCodes(
+                "&8&m         &2( &2&lAlchemicalTools &2) &8&m        "
+        ));
+
+        commandSender.sendMessage(StringFormatter.translateColorCodes(
+                "&2{syntax} &8- {description}".replace("{syntax}", this.getSyntax()).replace("{description}", this.getDescription())
+        ));
+
+        commandSender.sendMessage(StringFormatter.translateColorCodes(
+                "&8&m                                                 "
+        ));
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/framework/command/exception/SubCommandAlreadyMappedException.java
+++ b/src/main/java/io/github/ryanlaverick/framework/command/exception/SubCommandAlreadyMappedException.java
@@ -1,0 +1,18 @@
+package io.github.ryanlaverick.framework.command.exception;
+
+public final class SubCommandAlreadyMappedException extends RuntimeException {
+    private final String aggregateCommand;
+    private final String subCommand;
+
+    public SubCommandAlreadyMappedException(String aggregateCommand, String subCommand) {
+        this.aggregateCommand = aggregateCommand;
+        this.subCommand = subCommand;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Unable to register sub-command '%s' for command '%a'"
+                .replace("%s", this.subCommand)
+                .replace("%a", this.aggregateCommand);
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/framework/utility/StringFormatter.java
+++ b/src/main/java/io/github/ryanlaverick/framework/utility/StringFormatter.java
@@ -1,0 +1,9 @@
+package io.github.ryanlaverick.framework.utility;
+
+import org.bukkit.ChatColor;
+
+public final class StringFormatter {
+    public static String translateColorCodes(String message) {
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/item/Tool.java
+++ b/src/main/java/io/github/ryanlaverick/item/Tool.java
@@ -1,0 +1,25 @@
+package io.github.ryanlaverick.item;
+
+public enum Tool {
+    SMELTERS_PICKAXE("smelters_pickaxe");
+
+    private final String name;
+
+    Tool(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static Tool tryFrom(String key) {
+        for (Tool tools : Tool.values()) {
+            if (tools.getName().equalsIgnoreCase(key)) {
+                return tools;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,7 @@ version: 0.0.1-SNAPSHOT
 main: io.github.ryanlaverick.AlchemicalTools
 api-version: 1.19
 author: Ryan Laverick (Novur)
+
+commands:
+  alchemicaltools:
+    description: Root AlchemicalTools command


### PR DESCRIPTION
Creates a basic structure of nested commands with individual "handler" classes for each sub-command, which stops us having to handle all command cases within one `CommandExecutor` class that can be several hundred lines long.

Includes an example of a command that will be required down the line, but does not include things like configurable messages/prefixes