### PR TITLE
Setup basic item framework

### DIFF
--- a/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
+++ b/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
@@ -2,12 +2,14 @@ package io.github.ryanlaverick;
 
 import io.github.ryanlaverick.command.AlchemicalToolsCommand;
 import io.github.ryanlaverick.framework.file.ToolFileCache;
+import io.github.ryanlaverick.framework.item.ToolCache;
 import io.github.ryanlaverick.listener.CustomToolUsedListener;
 import io.github.ryanlaverick.listener.TriggerCustomToolUsedListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class AlchemicalTools extends JavaPlugin {
     private ToolFileCache toolFileCache;
+    private ToolCache toolCache;
 
     @Override
     public void onEnable() {
@@ -16,9 +18,10 @@ public class AlchemicalTools extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new TriggerCustomToolUsedListener(), this);
         this.getServer().getPluginManager().registerEvents(new CustomToolUsedListener(), this);
 
-        this.getCommand("alchemicaltools").setExecutor(new AlchemicalToolsCommand());
+        this.getCommand("alchemicaltools").setExecutor(new AlchemicalToolsCommand(this));
 
         this.toolFileCache = new ToolFileCache(this);
+        this.toolCache = new ToolCache(this);
     }
 
     @Override
@@ -28,5 +31,9 @@ public class AlchemicalTools extends JavaPlugin {
 
     public ToolFileCache getToolFileCache() {
         return toolFileCache;
+    }
+
+    public ToolCache getToolCache() {
+        return toolCache;
     }
 }

--- a/src/main/java/io/github/ryanlaverick/command/AlchemicalToolsCommand.java
+++ b/src/main/java/io/github/ryanlaverick/command/AlchemicalToolsCommand.java
@@ -1,5 +1,6 @@
 package io.github.ryanlaverick.command;
 
+import io.github.ryanlaverick.AlchemicalTools;
 import io.github.ryanlaverick.framework.command.AggregateCommand;
 import io.github.ryanlaverick.command.subcommands.GiveToolSubCommand;
 import org.bukkit.command.Command;
@@ -7,8 +8,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 public final class AlchemicalToolsCommand extends AggregateCommand {
-    public AlchemicalToolsCommand() {
-        this.registerSubCommand("give", new GiveToolSubCommand());
+    public AlchemicalToolsCommand(AlchemicalTools alchemicalTools) {
+        this.registerSubCommand("give", new GiveToolSubCommand(alchemicalTools));
     }
 
     @Override

--- a/src/main/java/io/github/ryanlaverick/command/subcommands/GiveToolSubCommand.java
+++ b/src/main/java/io/github/ryanlaverick/command/subcommands/GiveToolSubCommand.java
@@ -1,5 +1,6 @@
 package io.github.ryanlaverick.command.subcommands;
 
+import io.github.ryanlaverick.AlchemicalTools;
 import io.github.ryanlaverick.framework.command.SubCommand;
 import io.github.ryanlaverick.item.Tool;
 import org.bukkit.Bukkit;
@@ -7,6 +8,11 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 public final class GiveToolSubCommand extends SubCommand {
+    private AlchemicalTools alchemicalTools;
+    public GiveToolSubCommand(AlchemicalTools alchemicalTools) {
+        this.alchemicalTools = alchemicalTools;
+    }
+
     @Override
     public String getName() {
         return "alchemicaltools_give";
@@ -53,7 +59,7 @@ public final class GiveToolSubCommand extends SubCommand {
                 return true;
             }
 
-            commandSender.sendMessage("Giving player " + targetPlayer.getName() + " tool " + tool.getName());
+            ((Player) commandSender).getInventory().addItem(this.alchemicalTools.getToolCache().getItemStack(tool));
         }
 
         return true;

--- a/src/main/java/io/github/ryanlaverick/framework/item/NBTKey.java
+++ b/src/main/java/io/github/ryanlaverick/framework/item/NBTKey.java
@@ -1,0 +1,15 @@
+package io.github.ryanlaverick.framework.item;
+
+public enum NBTKey {
+    ALCHEMICAL_TOOLS_TYPE("alchemical_tools_type");
+
+    private final String key;
+
+    NBTKey(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/framework/item/ToolBuilder.java
+++ b/src/main/java/io/github/ryanlaverick/framework/item/ToolBuilder.java
@@ -1,0 +1,35 @@
+package io.github.ryanlaverick.framework.item;
+
+import io.github.ryanlaverick.AlchemicalTools;
+import io.github.ryanlaverick.framework.file.ToolFile;
+import io.github.ryanlaverick.framework.utility.StringFormatter;
+import io.github.ryanlaverick.item.Tool;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public final class ToolBuilder {
+    private final Tool tool;
+    private final AlchemicalTools alchemicalTools;
+    private final FileConfiguration toolFile;
+
+    public ToolBuilder(Tool tool, AlchemicalTools alchemicalTools) {
+        this.tool = tool;
+        this.alchemicalTools = alchemicalTools;
+
+        this.toolFile = this.alchemicalTools.getToolFileCache().getFile(this.tool).getFileConfiguration();
+    }
+
+    public ItemStack buildTool() {
+        Material material = Material.getMaterial(this.toolFile.getString("item.material"));
+        ItemStack itemStack = new ItemStack(material);
+
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        itemMeta.setDisplayName(StringFormatter.translateColorCodes(this.toolFile.getString("item.display_name")));
+
+        itemStack.setItemMeta(itemMeta);
+
+        return itemStack;
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/framework/item/ToolBuilder.java
+++ b/src/main/java/io/github/ryanlaverick/framework/item/ToolBuilder.java
@@ -5,19 +5,30 @@ import io.github.ryanlaverick.framework.file.ToolFile;
 import io.github.ryanlaverick.framework.utility.StringFormatter;
 import io.github.ryanlaverick.item.Tool;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public final class ToolBuilder {
     private final Tool tool;
     private final AlchemicalTools alchemicalTools;
     private final FileConfiguration toolFile;
 
+    private NamespacedKey toolTypeKey;
+
     public ToolBuilder(Tool tool, AlchemicalTools alchemicalTools) {
         this.tool = tool;
         this.alchemicalTools = alchemicalTools;
 
+        this.toolTypeKey = new NamespacedKey(alchemicalTools, NBTKey.ALCHEMICAL_TOOLS_TYPE.getKey());
         this.toolFile = this.alchemicalTools.getToolFileCache().getFile(this.tool).getFileConfiguration();
     }
 
@@ -26,7 +37,21 @@ public final class ToolBuilder {
         ItemStack itemStack = new ItemStack(material);
 
         ItemMeta itemMeta = itemStack.getItemMeta();
+
+        List<String> lore = new ArrayList<>();
+        for (String loreLine : this.toolFile.getStringList("item.lore")) {
+            lore.add(StringFormatter.translateColorCodes(loreLine));
+        }
+
         itemMeta.setDisplayName(StringFormatter.translateColorCodes(this.toolFile.getString("item.display_name")));
+        itemMeta.setLore(lore);
+
+        if (this.toolFile.getBoolean("item.flags.unbreakable")) {
+            itemMeta.setUnbreakable(true);
+        }
+
+        PersistentDataContainer persistentDataContainer = itemMeta.getPersistentDataContainer();
+        persistentDataContainer.set(this.toolTypeKey, PersistentDataType.STRING, this.tool.getName());
 
         itemStack.setItemMeta(itemMeta);
 

--- a/src/main/java/io/github/ryanlaverick/framework/item/ToolCache.java
+++ b/src/main/java/io/github/ryanlaverick/framework/item/ToolCache.java
@@ -1,0 +1,27 @@
+package io.github.ryanlaverick.framework.item;
+
+import io.github.ryanlaverick.AlchemicalTools;
+import io.github.ryanlaverick.item.Tool;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ToolCache {
+    private final AlchemicalTools alchemicalTools;
+    private final Map<Tool, ItemStack> cache;
+
+    public ToolCache(AlchemicalTools alchemicalTools) {
+        this.cache = new EnumMap<>(Tool.class);
+        this.alchemicalTools = alchemicalTools;
+
+        for (Tool tool : Tool.values()) {
+            this.cache.put(tool, new ToolBuilder(tool, this.alchemicalTools).buildTool());
+        }
+    }
+
+    public ItemStack getItemStack(Tool tool) {
+        return this.cache.get(tool);
+    }
+}

--- a/src/main/resources/tools/smelters_pickaxe.yml
+++ b/src/main/resources/tools/smelters_pickaxe.yml
@@ -1,5 +1,6 @@
 item:
-  material: DIAMOND_PICKAXE
+  material: 'DIAMOND_PICKAXE'
+  display_name: '&bSMELTERS PICKAXE'
   flags:
     unbreakable: true
     enchanted: true

--- a/src/main/resources/tools/smelters_pickaxe.yml
+++ b/src/main/resources/tools/smelters_pickaxe.yml
@@ -1,9 +1,11 @@
 item:
   material: 'DIAMOND_PICKAXE'
-  display_name: '&bSMELTERS PICKAXE'
+  display_name: '&7>>  &cSmelters Pickaxe'
+  lore:
+    - ''
+    - '&7>> &c&oInstantly smelt your ores!'
   flags:
     unbreakable: true
-    enchanted: true
 
 messages:
   test: foo


### PR DESCRIPTION
Sets up basic item framework and hooks this in with the existing `/bettertools give` command for proof-of-concept.

Work still to be done to add missing customisation fields, NBT tags etc.