### PR TITLE
Refactors custom event trigger to only fire when an AlchemicalTool is actually used

### DIFF
--- a/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
+++ b/src/main/java/io/github/ryanlaverick/AlchemicalTools.java
@@ -15,7 +15,7 @@ public class AlchemicalTools extends JavaPlugin {
     public void onEnable() {
         this.getLogger().info("Plugin Enabled");
 
-        this.getServer().getPluginManager().registerEvents(new TriggerCustomToolUsedListener(), this);
+        this.getServer().getPluginManager().registerEvents(new TriggerCustomToolUsedListener(this), this);
         this.getServer().getPluginManager().registerEvents(new CustomToolUsedListener(), this);
 
         this.getCommand("alchemicaltools").setExecutor(new AlchemicalToolsCommand(this));

--- a/src/main/java/io/github/ryanlaverick/framework/item/NBTUtility.java
+++ b/src/main/java/io/github/ryanlaverick/framework/item/NBTUtility.java
@@ -1,0 +1,37 @@
+package io.github.ryanlaverick.framework.item;
+
+import io.github.ryanlaverick.AlchemicalTools;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.naming.Name;
+
+public final class NBTUtility {
+    public final AlchemicalTools alchemicalTools;
+    public NBTUtility(AlchemicalTools alchemicalTools) {
+        this.alchemicalTools = alchemicalTools;
+    }
+
+    public boolean hasNBTKey(ItemStack itemStack, NBTKey key)
+    {
+        if (! itemStack.hasItemMeta()) {
+            return false;
+        }
+
+        ItemMeta itemMeta = itemStack.getItemMeta();
+
+        assert itemMeta != null;
+        PersistentDataContainer persistentDataContainer = itemMeta.getPersistentDataContainer();
+
+        for (NamespacedKey namespacedKey : persistentDataContainer.getKeys()) {
+            if (namespacedKey.getKey().equalsIgnoreCase(key.getKey())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/listener/TriggerCustomToolUsedListener.java
+++ b/src/main/java/io/github/ryanlaverick/listener/TriggerCustomToolUsedListener.java
@@ -1,6 +1,9 @@
 package io.github.ryanlaverick.listener;
 
+import io.github.ryanlaverick.AlchemicalTools;
 import io.github.ryanlaverick.event.CustomToolUsedEvent;
+import io.github.ryanlaverick.framework.item.NBTKey;
+import io.github.ryanlaverick.framework.item.NBTUtility;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -9,6 +12,10 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
 public final class TriggerCustomToolUsedListener implements Listener {
+    private final NBTUtility nbtUtility;
+    public TriggerCustomToolUsedListener(AlchemicalTools alchemicalTools) {
+        this.nbtUtility = new NBTUtility(alchemicalTools);
+    }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onBreak(BlockBreakEvent event) {
@@ -18,6 +25,8 @@ public final class TriggerCustomToolUsedListener implements Listener {
 
         if (itemInHand.getType().isAir()) return;
 
-        Bukkit.getServer().getPluginManager().callEvent(new CustomToolUsedEvent(event.getPlayer(), itemInHand));
+        if (this.nbtUtility.hasNBTKey(itemInHand, NBTKey.ALCHEMICAL_TOOLS_TYPE)) {
+            Bukkit.getServer().getPluginManager().callEvent(new CustomToolUsedEvent(event.getPlayer(), itemInHand));
+        }
     }
 }


### PR DESCRIPTION
Reworks how the event firing works for when an Alchemical Tool is used. Previously this would fire on any tool, regardless of whether or not it is actually an Alchemical Tool.

We determine this based on the presence of `alchemical_tools_type` within the item's Persistent Data Container.