### PR TITLE
Set up basic Sound framework

### DIFF
--- a/src/main/java/io/github/ryanlaverick/framework/sound/SoundProfile.java
+++ b/src/main/java/io/github/ryanlaverick/framework/sound/SoundProfile.java
@@ -1,5 +1,6 @@
 package io.github.ryanlaverick.framework.sound;
 
+import io.github.ryanlaverick.AlchemicalTools;
 import io.github.ryanlaverick.framework.item.Tool;
 import io.github.ryanlaverick.framework.sound.exception.InvalidSoundException;
 import org.bukkit.Sound;
@@ -7,22 +8,25 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 public final class SoundProfile {
-    private final boolean shouldPlaySound;
+    private boolean shouldPlaySound;
     private Sound sound = null;
     private float pitch = 1.0F;
     private float volume = 1.0F;
 
-    public SoundProfile(FileConfiguration configurationFile) {
+    public SoundProfile(AlchemicalTools alchemicalTools, FileConfiguration configurationFile) {
         this.shouldPlaySound = configurationFile.getBoolean("options.sound.plays_sound");
 
         if (! this.shouldPlaySound) {
             return;
         }
 
+        String soundString = configurationFile.getString("options.sound.sound");
+
         try {
-            this.sound = Sound.valueOf(configurationFile.getString("options.sound.sound"));
+            this.sound = Sound.valueOf(soundString);
         } catch (IllegalArgumentException|NullPointerException ignored) {
-            throw new InvalidSoundException(configurationFile.getString("options.sound.sound"));
+            alchemicalTools.getLogger().severe("Unable to parse Sound {sound}".replace("{sound}", soundString));
+            this.shouldPlaySound = false;
         }
 
         this.pitch = (float) configurationFile.getDouble("options.sound.pitch");

--- a/src/main/java/io/github/ryanlaverick/framework/sound/SoundProfile.java
+++ b/src/main/java/io/github/ryanlaverick/framework/sound/SoundProfile.java
@@ -1,8 +1,6 @@
 package io.github.ryanlaverick.framework.sound;
 
 import io.github.ryanlaverick.AlchemicalTools;
-import io.github.ryanlaverick.framework.item.Tool;
-import io.github.ryanlaverick.framework.sound.exception.InvalidSoundException;
 import org.bukkit.Sound;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;

--- a/src/main/java/io/github/ryanlaverick/framework/sound/SoundProfile.java
+++ b/src/main/java/io/github/ryanlaverick/framework/sound/SoundProfile.java
@@ -1,0 +1,39 @@
+package io.github.ryanlaverick.framework.sound;
+
+import io.github.ryanlaverick.framework.item.Tool;
+import io.github.ryanlaverick.framework.sound.exception.InvalidSoundException;
+import org.bukkit.Sound;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+public final class SoundProfile {
+    private final boolean shouldPlaySound;
+    private Sound sound = null;
+    private float pitch = 1.0F;
+    private float volume = 1.0F;
+
+    public SoundProfile(FileConfiguration configurationFile) {
+        this.shouldPlaySound = configurationFile.getBoolean("options.sound.plays_sound");
+
+        if (! this.shouldPlaySound) {
+            return;
+        }
+
+        try {
+            this.sound = Sound.valueOf(configurationFile.getString("options.sound.sound"));
+        } catch (IllegalArgumentException|NullPointerException ignored) {
+            throw new InvalidSoundException(configurationFile.getString("options.sound.sound"));
+        }
+
+        this.pitch = (float) configurationFile.getDouble("options.sound.pitch");
+        this.volume = (float) configurationFile.getDouble("options.sound.volume");
+    }
+
+    public void play(Player player) {
+        if (! this.shouldPlaySound) {
+            return;
+        }
+
+        player.playSound(player, this.sound, this.volume, this.pitch);
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/framework/sound/exception/InvalidSoundException.java
+++ b/src/main/java/io/github/ryanlaverick/framework/sound/exception/InvalidSoundException.java
@@ -1,0 +1,7 @@
+package io.github.ryanlaverick.framework.sound.exception;
+
+public final class InvalidSoundException extends RuntimeException {
+    public InvalidSoundException(String invalidSound) {
+        super("Unable to parse Sound {sound}".replace("{sound}", invalidSound));
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/handler/SmeltersPickaxeHandler.java
+++ b/src/main/java/io/github/ryanlaverick/handler/SmeltersPickaxeHandler.java
@@ -5,7 +5,6 @@ import io.github.ryanlaverick.event.CustomToolUsedEvent;
 import io.github.ryanlaverick.framework.item.Tool;
 import io.github.ryanlaverick.framework.item.ToolHandler;
 import io.github.ryanlaverick.framework.sound.SoundProfile;
-import io.github.ryanlaverick.framework.sound.exception.InvalidSoundException;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -65,11 +64,7 @@ public final class SmeltersPickaxeHandler extends ToolHandler {
         if (toolFile.isConfigurationSection("options")) {
             this.dropsToFloor = toolFile.getBoolean("options.drops_to_floor");
 
-            try {
-                this.soundProfile = new SoundProfile(alchemicalTools, toolFile);
-            } catch (InvalidSoundException ex) {
-                alchemicalTools.getLogger().severe(ex.getMessage());
-            }
+            this.soundProfile = new SoundProfile(alchemicalTools, toolFile);
         }
     }
 

--- a/src/main/java/io/github/ryanlaverick/handler/SmeltersPickaxeHandler.java
+++ b/src/main/java/io/github/ryanlaverick/handler/SmeltersPickaxeHandler.java
@@ -4,6 +4,8 @@ import io.github.ryanlaverick.AlchemicalTools;
 import io.github.ryanlaverick.event.CustomToolUsedEvent;
 import io.github.ryanlaverick.framework.item.Tool;
 import io.github.ryanlaverick.framework.item.ToolHandler;
+import io.github.ryanlaverick.framework.sound.SoundProfile;
+import io.github.ryanlaverick.framework.sound.exception.InvalidSoundException;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -20,6 +22,7 @@ import java.util.Set;
 
 public final class SmeltersPickaxeHandler extends ToolHandler {
     private final Map<Material, Material> materialMap;
+    private SoundProfile soundProfile;
     private boolean dropsToFloor = true;
 
     public SmeltersPickaxeHandler(AlchemicalTools alchemicalTools) {
@@ -31,7 +34,6 @@ public final class SmeltersPickaxeHandler extends ToolHandler {
     @Override
     public void load(AlchemicalTools alchemicalTools) {
         FileConfiguration toolFile = alchemicalTools.getToolFileCache().getFile(Tool.SMELTERS_PICKAXE).getFileConfiguration();
-
         if (toolFile.isConfigurationSection("conversions")) {
             Set<String> mappings = toolFile.getConfigurationSection("conversions").getKeys(false);
 
@@ -60,7 +62,11 @@ public final class SmeltersPickaxeHandler extends ToolHandler {
             }
         }
 
-        this.dropsToFloor = toolFile.getBoolean("options.drops_to_floor");
+        if (toolFile.isConfigurationSection("options")) {
+            this.dropsToFloor = toolFile.getBoolean("options.drops_to_floor");
+
+            this.soundProfile = new SoundProfile(toolFile);
+        }
     }
 
     @Override
@@ -81,15 +87,16 @@ public final class SmeltersPickaxeHandler extends ToolHandler {
             return;
         }
 
+        Player player = customToolUsedEvent.getPlayer();
         Material material = this.materialMap.get(block.getType());
         ItemStack itemStack = new ItemStack(material);
 
         blockBreakEvent.setDropItems(false);
+        this.soundProfile.play(player);
 
         if (this.dropsToFloor) {
             world.dropItemNaturally(block.getLocation(), itemStack);
         } else {
-            Player player = customToolUsedEvent.getPlayer();
             player.getInventory().addItem(itemStack);
         }
     }

--- a/src/main/java/io/github/ryanlaverick/handler/SmeltersPickaxeHandler.java
+++ b/src/main/java/io/github/ryanlaverick/handler/SmeltersPickaxeHandler.java
@@ -65,7 +65,11 @@ public final class SmeltersPickaxeHandler extends ToolHandler {
         if (toolFile.isConfigurationSection("options")) {
             this.dropsToFloor = toolFile.getBoolean("options.drops_to_floor");
 
-            this.soundProfile = new SoundProfile(toolFile);
+            try {
+                this.soundProfile = new SoundProfile(alchemicalTools, toolFile);
+            } catch (InvalidSoundException ex) {
+                alchemicalTools.getLogger().severe(ex.getMessage());
+            }
         }
     }
 

--- a/src/main/resources/tools/smelters_pickaxe.yml
+++ b/src/main/resources/tools/smelters_pickaxe.yml
@@ -19,6 +19,11 @@ conversions:
 
 options:
   drops_to_floor: true
+  sound:
+    plays_sound: true
+    sound: 'ENTITY_BLAZE_HURT'
+    volume: 1
+    pitch: 1
 
 messages:
   test: foo

--- a/src/main/resources/tools/smelters_pickaxe.yml
+++ b/src/main/resources/tools/smelters_pickaxe.yml
@@ -5,7 +5,7 @@ item:
     - ''
     - '&7>> &c&oInstantly smelt your ores!'
   flags:
-    unbreakable: true
+    unbreakable: true # Determines if the item should be unbreakable (unaffected by durability)
 
 conversions:
   STONE:
@@ -18,12 +18,12 @@ conversions:
     to: 'NETHERITE_SCRAP'
 
 options:
-  drops_to_floor: true
+  drops_to_floor: true # Determines if the item is dropped to the floor (true) or is added directly to the user's inventory (false)
   sound:
-    plays_sound: true
-    sound: 'ENTITY_BLAZE_HURT'
-    volume: 1
-    pitch: 1
+    plays_sound: true # Set this to `false` if no sound should be played
+    sound: 'ENTITY_BLAZE_HURT' # See: https://helpch.at/docs/1.19/org/bukkit/Sound.html -- if a valid Sound cannot be parsed we override `plays_sound` to being `false`
+    volume: 1 # Determines overall volume of Sound that is played to the user
+    pitch: 1 # Determines overall pitch of Sound that is played to the user
 
 messages:
   test: foo


### PR DESCRIPTION
Used for playing Sounds when an Alchemical Tool is successfully used, each Tool has its own sound configuration as described in the relevant tool file:

```yaml
options:
  ...
  sound:
    plays_sound: true # Set this to `false` if no sound should be played
    sound: 'ENTITY_BLAZE_HURT' # See: https://helpch.at/docs/1.19/org/bukkit/Sound.html -- if a valid Sound cannot be parsed we override `plays_sound` to being `false`
    volume: 1 # Determines overall volume of Sound that is played to the user
    pitch: 1 # Determines overall pitch of Sound that is played to the user
```

Again the loading of this information has been delegated to the `load()` function within the tool handler. This is to facilitate reloading of the config without having to restart the server which will be added down the line.