### PR TITLE
Setup basic Effect framework

### DIFF
--- a/src/main/java/io/github/ryanlaverick/framework/effect/EffectProfile.java
+++ b/src/main/java/io/github/ryanlaverick/framework/effect/EffectProfile.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 public final class EffectProfile {
     private boolean shouldPlayEffect;
     private Effect effect = null;
+    private int data = 0;
 
     public EffectProfile(AlchemicalTools alchemicalTools, FileConfiguration configurationFile) {
         this.shouldPlayEffect = configurationFile.getBoolean("options.effect.plays_effect");
@@ -25,6 +26,8 @@ public final class EffectProfile {
             alchemicalTools.getLogger().severe("Unable to parse Effect {effect}".replace("{effect}", effectString));
             this.shouldPlayEffect = false;
         }
+
+        this.data = configurationFile.getInt("options.effect.data");
     }
 
     public void play(Player player, Location location) {
@@ -32,6 +35,6 @@ public final class EffectProfile {
             return;
         }
 
-        player.playEffect(location, this.effect, null);
+        player.playEffect(location, this.effect, this.data);
     }
 }

--- a/src/main/java/io/github/ryanlaverick/framework/effect/EffectProfile.java
+++ b/src/main/java/io/github/ryanlaverick/framework/effect/EffectProfile.java
@@ -1,0 +1,37 @@
+package io.github.ryanlaverick.framework.effect;
+
+import io.github.ryanlaverick.AlchemicalTools;
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+public final class EffectProfile {
+    private boolean shouldPlayEffect;
+    private Effect effect = null;
+
+    public EffectProfile(AlchemicalTools alchemicalTools, FileConfiguration configurationFile) {
+        this.shouldPlayEffect = configurationFile.getBoolean("options.effect.plays_effect");
+
+        if (! this.shouldPlayEffect) {
+            return;
+        }
+
+        String effectString = configurationFile.getString("options.effect.effect");
+
+        try {
+            this.effect = Effect.valueOf(effectString);
+        } catch (IllegalArgumentException|NullPointerException ignored) {
+            alchemicalTools.getLogger().severe("Unable to parse Effect {effect}".replace("{effect}", effectString));
+            this.shouldPlayEffect = false;
+        }
+    }
+
+    public void play(Player player, Location location) {
+        if (! this.shouldPlayEffect) {
+            return;
+        }
+
+        player.playEffect(location, this.effect, null);
+    }
+}

--- a/src/main/java/io/github/ryanlaverick/framework/sound/exception/InvalidSoundException.java
+++ b/src/main/java/io/github/ryanlaverick/framework/sound/exception/InvalidSoundException.java
@@ -1,7 +1,0 @@
-package io.github.ryanlaverick.framework.sound.exception;
-
-public final class InvalidSoundException extends RuntimeException {
-    public InvalidSoundException(String invalidSound) {
-        super("Unable to parse Sound {sound}".replace("{sound}", invalidSound));
-    }
-}

--- a/src/main/java/io/github/ryanlaverick/handler/SmeltersPickaxeHandler.java
+++ b/src/main/java/io/github/ryanlaverick/handler/SmeltersPickaxeHandler.java
@@ -2,6 +2,7 @@ package io.github.ryanlaverick.handler;
 
 import io.github.ryanlaverick.AlchemicalTools;
 import io.github.ryanlaverick.event.CustomToolUsedEvent;
+import io.github.ryanlaverick.framework.effect.EffectProfile;
 import io.github.ryanlaverick.framework.item.Tool;
 import io.github.ryanlaverick.framework.item.ToolHandler;
 import io.github.ryanlaverick.framework.sound.SoundProfile;
@@ -22,6 +23,7 @@ import java.util.Set;
 public final class SmeltersPickaxeHandler extends ToolHandler {
     private final Map<Material, Material> materialMap;
     private SoundProfile soundProfile;
+    private EffectProfile effectProfile;
     private boolean dropsToFloor = true;
 
     public SmeltersPickaxeHandler(AlchemicalTools alchemicalTools) {
@@ -65,6 +67,7 @@ public final class SmeltersPickaxeHandler extends ToolHandler {
             this.dropsToFloor = toolFile.getBoolean("options.drops_to_floor");
 
             this.soundProfile = new SoundProfile(alchemicalTools, toolFile);
+            this.effectProfile = new EffectProfile(alchemicalTools, toolFile);
         }
     }
 
@@ -91,7 +94,9 @@ public final class SmeltersPickaxeHandler extends ToolHandler {
         ItemStack itemStack = new ItemStack(material);
 
         blockBreakEvent.setDropItems(false);
+        
         this.soundProfile.play(player);
+        this.effectProfile.play(player, block.getLocation());
 
         if (this.dropsToFloor) {
             world.dropItemNaturally(block.getLocation(), itemStack);

--- a/src/main/resources/tools/smelters_pickaxe.yml
+++ b/src/main/resources/tools/smelters_pickaxe.yml
@@ -20,10 +20,14 @@ conversions:
 options:
   drops_to_floor: true # Determines if the item is dropped to the floor (true) or is added directly to the user's inventory (false)
   sound:
-    plays_sound: true # Set this to `false` if no sound should be played
+    plays_sound: true # Set this to `false` if no Sound should be played
     sound: 'ENTITY_BLAZE_HURT' # See: https://helpch.at/docs/1.19/org/bukkit/Sound.html -- if a valid Sound cannot be parsed we override `plays_sound` to being `false`
     volume: 1 # Determines overall volume of Sound that is played to the user
     pitch: 1 # Determines overall pitch of Sound that is played to the user
+  effect:
+    plays_effect: true # Set this to `false` if no Effect should be played
+    effect: 'SMOKE' # See: https://helpch.at/docs/1.19/org/bukkit/Effect.html -- if a valid Effect cannot be parsed we override `plays_effect` to being `false`
+    data: 10 # Data bit associated with the Effect -- for the 'SMOKE' Effect this seems to be the multiplier
 
 messages:
   test: foo


### PR DESCRIPTION
Introduces EffectProfiles, which are used to play configurable Effects when an Alchemical Tool is used. Currently other Alchemical Tools have not been implemented, which is why this PR only contains the set up for EffectProfiles with the Smelters Pickaxe.

EffectProfiles are configurable on a per-Tool basis, which can be found in the relevant Tool file:

```yaml
options:
  ...
  effect:
    plays_effect: true # Set this to `false` if no Effect should be played
    effect: 'SMOKE' # See: https://helpch.at/docs/1.19/org/bukkit/Effect.html -- if a valid Effect cannot be parsed we override `plays_effect` to being `false`
    data: 10 # Data bit associated with the Effect -- for the 'SMOKE' Effect this seems to be the multiplier
```
